### PR TITLE
Update zbxTelegram.py

### DIFF
--- a/zbxTelegram.py
+++ b/zbxTelegram.py
@@ -63,7 +63,12 @@ class FailSafeDict(dict):
 args = ArgParsing().create_parser().parse_args(sys.argv[1:])
 loggings = System(config_debug_mode if not args.debug else True).log
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+if args.token:
+    tg_token = args.token
+
 bot = telebot.TeleBot(tg_token)
+
 if tg_proxy:
     apihelper.proxy = tg_proxy_server
 


### PR DESCRIPTION
Add set token from command args. Token from args has high priority. This will allow to configure telegram bot token directly from zabbix.